### PR TITLE
fix : Monster와 Player전투 시 Hp 적용 안되던 문제, 죽은 몬스터 HP 표시 Dead로 설정

### DIFF
--- a/NotepadKnights/BattleManager.cs
+++ b/NotepadKnights/BattleManager.cs
@@ -16,7 +16,7 @@ namespace NotepadKnights
     }
     internal class BattleManager
     {
-
+        AttackAndDefense atkAndDef = new AttackAndDefense();
         // 플레이어 차례
         public void ExecutePlayerPhase()
         {
@@ -42,13 +42,18 @@ namespace NotepadKnights
             {
                 if (monster.CurrentHp <= 0) { continue; }
                 int monsterAtk = monster.DealDamage();
+                int playerHpAfterDamaged = atkAndDef.PlayerDefense(monsterAtk, Program.playerStatus.Hp, Program.playerStatus.Defense);
+                
                 Console.Clear();
                 Console.WriteLine($"Lv.{monster.Level} {monster.Name} 의 공격!");
-                Console.WriteLine($"{Program.playerStatus.Name} 을(를) 맞췄습니다.   [데미지 : {Program.playerStatus.Defense - monster.Atk}]");
+                Thread.Sleep(1000);
+                Console.WriteLine($"{Program.playerStatus.Name} 을(를) 맞췄습니다.   [데미지 : {monster.Atk - Program.playerStatus.Defense}]");
                 Console.WriteLine();
                 Console.WriteLine($"Lv.{Program.playerStatus.Level} {Program.playerStatus.Name}");
-                Console.WriteLine($"HP {Program.playerStatus.Hp} -> {Program.playerStatus.Hp - monster.Atk}");
-                Console.WriteLine();
+                Console.WriteLine($"HP {Program.playerStatus.Hp} -> {playerHpAfterDamaged}");
+
+                // 위의 공격 주고 받는 부분 출력 이후 계산
+                Program.playerStatus.Hp = playerHpAfterDamaged;
                 Console.WriteLine("0. 다음");
 
                 while (true)
@@ -64,6 +69,7 @@ namespace NotepadKnights
                     }
                 }
             }
+            Console.Clear();
             Console.WriteLine("몬스터들의 공격 차례가 끝났습니다.");
             Thread.Sleep(1000);
 

--- a/NotepadKnights/Player/PlayerStatus.cs
+++ b/NotepadKnights/Player/PlayerStatus.cs
@@ -11,7 +11,7 @@ namespace NotepadKnights
         public string Name { get; private set; }
         public string Job { get; private set; }
         public int Level { get; private set; }
-        public int Hp { get; private set; }
+        public int Hp { get; set; }
         public int MaxHp { get; private set; }
         public int Mp { get; private set; }
         public int Exp { get; private set; } // 현재 경험치
@@ -34,7 +34,7 @@ namespace NotepadKnights
             MaxHp = 100;
             Mp = 100;
             Attack = 10;
-            Defense = 10;
+            Defense = 5;
         }
         // 혹시 몰라서 넣음 , 이름 변경
         public void SetName(string name)

--- a/NotepadKnights/Player/PlayerUI.cs
+++ b/NotepadKnights/Player/PlayerUI.cs
@@ -39,7 +39,8 @@ namespace NotepadKnights
                         monsterIndexDisplay = Program.playerStatus.IsAttack ? (i + 1).ToString() : "";
 
                         var monster = Program.monsterFactory.createMonsters[i];
-                        Console.WriteLine($"{monsterIndexDisplay} Lv.{monster.Level} {monster.Name} HP {monster.CurrentHp} ");
+                        string monsterHpTxt = monster.IsDead ? $"Dead" : $"HP {monster.CurrentHp}";
+                        Console.WriteLine($"{monsterIndexDisplay} Lv.{monster.Level} {monster.Name} {monsterHpTxt}");
                     }
 
                     Console.WriteLine("\n\n[내정보]");
@@ -81,11 +82,11 @@ namespace NotepadKnights
 
             Console.WriteLine($"Lv.{playerTarget.Level} {playerTarget.Name} 을(를) 맞췄습니다. [데미지 : {playerDamage}]\n");
             Console.WriteLine($"Lv.{playerTarget.Level} {playerTarget.Name}");
+            playerTarget.ApplyDamage(playerDamage);
 
             //  적이 죽었으면
-            if( playerTarget.CurrentHp <= 0 || playerTarget.IsDead )
+            if (playerTarget.IsDead)
             {
-                playerTarget.CurrentHp = 0;
                 playerTarget = null;
                 Console.WriteLine( $"HP 0 ->Dead\n");
                 Program.playerStatus.SetKilledMonsterCount(Program.playerStatus.KilledMonsterCount+1);


### PR DESCRIPTION
- 몬스터와 플레이어가 전투 시 Hp가 제대로 적용되지 않던 문제 수정
- PlayerUI부분에 죽은 몬스터를 체크하는 부분에 몬스터 클래스의 applydamage 함수를 이용해 isDead체크
- 플레이어 defence를 10에서 5로 변경