### PR TITLE
fix : 텍스트 색깔 오류 수정

### DIFF
--- a/NotepadKnights/BattleManager.cs
+++ b/NotepadKnights/BattleManager.cs
@@ -135,8 +135,8 @@ namespace NotepadKnights
                 var monster = _monsterFactory.createMonsters[i];
                 string monsterHpTxt = monster.IsDead ? "Dead" : $"HP {monster.CurrentHp}";
                 if (monster.IsDead) Console.ForegroundColor = ConsoleColor.DarkGray;
-                else Console.ResetColor();
                 Console.WriteLine($"{monsterIndexDisplay} Lv.{monster.Level} {monster.Name} {monsterHpTxt}");
+                Console.ResetColor();
             }
         }
 


### PR DESCRIPTION
- 맨 마지막 몬스터를 먼저 잡을 경우, 다음 나오는 텍스트들이 전부 DarkGray로 나오는 오류를 수정